### PR TITLE
Truck status fix

### DIFF
--- a/app/infoCards/truckCard.tsx
+++ b/app/infoCards/truckCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { ReactElement } from "react";
+import React, { ReactElement, useState } from "react";
 
 interface Driver {
   id: string | number;
@@ -17,6 +17,7 @@ interface Truck {
   location: string;
   status: "Available" | "In Use";
   driver: Driver | null;
+  downForService?: boolean; // ✅ new optional flag
 }
 
 interface TruckCardProps {
@@ -29,22 +30,42 @@ interface TruckListProps {
   viewMode: "compact" | "detailed";
 }
 
-// TruckCard component with two display modes: compact and detailed
 export default function TruckCard({
   truck,
   viewMode,
 }: TruckCardProps): ReactElement {
+  const [isDown, setIsDown] = useState<boolean>(truck.downForService ?? false);
+
+  const handleToggle = () => {
+    setIsDown((prev) => !prev);
+    // You can add API/supabase update logic here if needed
+  };
+
   return (
     <div
       className={`truck-card ${
         viewMode === "compact" ? "p-2 text-sm" : "p-4 text-base"
-      } border rounded-lg shadow-md`}
+      } border rounded-lg shadow-md relative`}
     >
       <h3
         className={`font-bold ${viewMode === "compact" ? "text-sm" : "text-xl"} mb-2`}
       >
         {truck.name}
       </h3>
+
+      {/* ✅ Toggle */}
+      <label className="inline-flex items-center gap-2 text-sm mb-2">
+        <input type="checkbox" checked={isDown} onChange={handleToggle} />
+        <span>Down for Service</span>
+      </label>
+
+      {/* ✅ Red Badge */}
+      {isDown && (
+        <p className="text-red-600 font-semibold text-sm mb-2">
+          🚫 Truck is currently down for service.
+        </p>
+      )}
+
       {viewMode === "detailed" && (
         <>
           <p>
@@ -57,6 +78,7 @@ export default function TruckCard({
           <p className="text-primary-medium mb-2">Location: {truck.location}</p>
         </>
       )}
+
       <div className="mt-2">
         <span
           className={`badge ${
@@ -66,6 +88,7 @@ export default function TruckCard({
           {truck.status}
         </span>
       </div>
+
       <div className="mt-4">
         <h4 className="font-bold text-md">Assigned Driver:</h4>
         {truck.driver ? (
@@ -90,7 +113,7 @@ export default function TruckCard({
   );
 }
 
-// Example usage of TruckCard
+// ✅ TruckList stays the same
 export function TruckList({ trucks, viewMode }: TruckListProps): ReactElement {
   return (
     <div
@@ -106,5 +129,3 @@ export function TruckList({ trucks, viewMode }: TruckListProps): ReactElement {
     </div>
   );
 }
-
-// Example data for testing

--- a/app/schedule/components/Calendar.tsx
+++ b/app/schedule/components/Calendar.tsx
@@ -70,6 +70,16 @@ export const Calendar = ({
           right: "",
         }}
         dayHeaderFormat={{ weekday: "long", day: "numeric" }}
+        dayHeaderContent={({ date }) => {
+          const dayName = date.toLocaleDateString("en-US", { weekday: "short" });
+          const dayNum = date.getDate();
+          return (
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+              <div>{dayNum}</div>
+              <div>{dayName}</div>
+            </div>
+          );
+        }}
         dayCellClassNames="custom-day-cell"
         eventClassNames="custom-event-wrapper"
         slotMinTime="00:00:00"
@@ -89,6 +99,7 @@ export const Calendar = ({
         dayMaxEventRows={viewMode === "monthly" ? false : 3}
         eventDisplay="block"
         eventOverlap={false}
+        firstDay={1}
         eventConstraint={{
           startTime: "00:00:00",
           endTime: "24:00:00",

--- a/app/schedule/components/Calendar.tsx
+++ b/app/schedule/components/Calendar.tsx
@@ -43,7 +43,7 @@ export const Calendar = ({
     viewMode === "daily"
       ? "timeGridDay"
       : viewMode === "weekly"
-        ? "timeGridWeek"
+        ? "dayGridWeek" 
         : "dayGridMonth";
 
   return (

--- a/app/types.ts
+++ b/app/types.ts
@@ -62,6 +62,7 @@ export interface Truck {
   };
   location: string;
   isAvailable: boolean;
+  downForService: false
 }
 
 export interface TruckFormData extends Omit<Truck, 'id' | 'driver'> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "yyc-foodtruck",
       "version": "0.1.0",
       "dependencies": {
+        "@daypilot/daypilot-lite-react": "^4.0.2",
         "@fullcalendar/daygrid": "^6.1.17",
         "@fullcalendar/interaction": "^6.1.17",
         "@fullcalendar/react": "^6.1.17",
@@ -30,6 +31,7 @@
         "@types/node": "^20.19.0",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.2.19",
+        "@types/react-tooltip": "^4.2.4",
         "autoprefixer": "^10.4.21",
         "eslint": "^8.56.0",
         "eslint-config-next": "14.1.0",
@@ -52,6 +54,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@daypilot/daypilot-lite-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@daypilot/daypilot-lite-javascript/-/daypilot-lite-javascript-4.0.2.tgz",
+      "integrity": "sha512-nCoN2OZxiUCh/PQiZyPNpmk5jTiYBQ/m++38RIIQBycPAK7rBEb/nznM4p8PWxbmGM2xYE/Q0Yggh+Hq5OFgFQ=="
+    },
+    "node_modules/@daypilot/daypilot-lite-react": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@daypilot/daypilot-lite-react/-/daypilot-lite-react-4.0.2.tgz",
+      "integrity": "sha512-mPAAPHuI0EN58PG4edKi4HjAiaxwjTpWjnXTJbmlNnBRkPiLQ95bN9LYZ1TjJcQDboqXaRWIgEgyZrZFGhOWcw==",
+      "dependencies": {
+        "@daypilot/daypilot-lite-javascript": "4.0.2",
+        "create-react-class": ">=15.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -738,6 +758,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-tooltip": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-tooltip/-/react-tooltip-4.2.4.tgz",
+      "integrity": "sha512-UzjzmgY/VH3Str6DcAGTLMA1mVVhGOyARNTANExrirtp+JgxhaIOVDxq4TIRmpSi4voLv+w4HA9CC5GvhhCA0A==",
+      "deprecated": "This is a stub types definition. react-tooltip provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "react-tooltip": "*"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -1727,6 +1757,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -1778,6 +1814,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/create-react-class": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
+      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
+      "dependencies": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4258,7 +4303,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4878,6 +4922,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.1.tgz",
+      "integrity": "sha512-ZA4oHwoIIK09TS7PvSLFcRlje1wGZaxw6xHvfrzn6T82UcMEfEmHVCad16Gnr4NDNDh93HyN037VK4HDi5odfQ==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
-        "@types/node": "^20.11.19",
-        "@types/react": "^18.2.57",
+        "@types/node": "^20.19.0",
+        "@types/react": "^18.3.23",
         "@types/react-dom": "^18.2.19",
         "autoprefixer": "^10.4.21",
         "eslint": "^8.56.0",
@@ -38,7 +38,7 @@
         "postcss": "^8.5.4",
         "prettier": "^3.2.5",
         "tailwindcss": "^3.4.17",
-        "typescript": "^5.3.3"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -696,13 +696,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.57",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
-      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -715,7 +714,6 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5996,7 +5994,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6025,11 +6022,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "node_modules/unrs-resolver": {
       "version": "1.7.9",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@daypilot/daypilot-lite-react": "^4.0.2",
     "@fullcalendar/daygrid": "^6.1.17",
     "@fullcalendar/interaction": "^6.1.17",
     "@fullcalendar/react": "^6.1.17",
@@ -31,6 +32,7 @@
     "@types/node": "^20.19.0",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.2.19",
+    "@types/react-tooltip": "^4.2.4",
     "autoprefixer": "^10.4.21",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.1.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
-    "@types/node": "^20.11.19",
-    "@types/react": "^18.2.57",
+    "@types/node": "^20.19.0",
+    "@types/react": "^18.3.23",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.4.21",
     "eslint": "^8.56.0",
@@ -39,6 +39,6 @@
     "postcss": "^8.5.4",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.3.3"
+    "typescript": "^5.8.3"
   }
 }

--- a/public/events.json
+++ b/public/events.json
@@ -218,5 +218,31 @@
     "assignedStaff": [],
     "requiredServers": 8,
     "status": "Scheduled"
+  },
+  {
+    "id": "13",
+    "title": "birthday party",
+    "startTime": "2025-06-10T14:00",
+    "endTime": "2025-06-10T17:00",
+    "location": "24 castleridge way ne , Calgary, T3J 2A3",
+    "coordinates": {
+      "latitude": 51.1086129,
+      "longitude": -113.9478816
+    },
+    "trucks": [
+      "2"
+    ],
+    "assignedStaff": [
+      "7",
+      "9",
+      "10",
+      "6",
+      "8"
+    ],
+    "requiredServers": 5,
+    "status": "Scheduled",
+    "contactName": "TEHJIB SINGH",
+    "contactEmail": "062tehjibsingh@gmail.com",
+    "contactPhone": "3682995830"
   }
 ]

--- a/public/events.json
+++ b/public/events.json
@@ -244,5 +244,161 @@
     "contactName": "TEHJIB SINGH",
     "contactEmail": "062tehjibsingh@gmail.com",
     "contactPhone": "3682995830"
+  },
+  {
+    "id": "14",
+    "title": "nagarkirtan",
+    "startTime": "2025-06-10T06:00",
+    "endTime": "2025-06-10T13:00",
+    "location": "7064 temple drive NE, Calgary, T1Y 4E5",
+    "coordinates": {
+      "latitude": 51.0916085,
+      "longitude": -113.9520823
+    },
+    "trucks": [
+      "8"
+    ],
+    "assignedStaff": [
+      "10",
+      "7",
+      "9",
+      "6",
+      "8"
+    ],
+    "requiredServers": 5,
+    "status": "Scheduled",
+    "contactName": "TEHJIB SINGH",
+    "contactEmail": "062tehjibsingh@gmail.com",
+    "contactPhone": "3682995830"
+  },
+  {
+    "id": "15",
+    "title": "birthday party",
+    "startTime": "2025-06-10T14:00",
+    "endTime": "2025-06-10T17:00",
+    "location": "7064 temple drive NE, Calgary, T1Y 4E5",
+    "coordinates": {
+      "latitude": 51.0916085,
+      "longitude": -113.9520823
+    },
+    "trucks": [
+      "12"
+    ],
+    "assignedStaff": [
+      "10",
+      "7",
+      "9",
+      "6",
+      "8"
+    ],
+    "requiredServers": 5,
+    "status": "Scheduled",
+    "contactName": "TEHJIB SINGH",
+    "contactEmail": "062tehjibsingh@gmail.com",
+    "contactPhone": "3682995830"
+  },
+  {
+    "id": "16",
+    "title": "pool party",
+    "startTime": "2025-06-12T14:00",
+    "endTime": "2025-06-12T17:00",
+    "location": "7064 temple drive NE, Calgary, T1Y 4E5",
+    "coordinates": {
+      "latitude": 51.0916085,
+      "longitude": -113.9520823
+    },
+    "trucks": [
+      "6"
+    ],
+    "assignedStaff": [
+      "10",
+      "7",
+      "9",
+      "6",
+      "8"
+    ],
+    "requiredServers": 5,
+    "status": "Scheduled",
+    "contactName": "TEHJIB SINGH",
+    "contactEmail": "062tehjibsingh@gmail.com",
+    "contactPhone": "3682995830"
+  },
+  {
+    "id": "17",
+    "title": "birthday party",
+    "startTime": "2025-06-12T14:00",
+    "endTime": "2025-06-12T17:00",
+    "location": "7064 temple drive NE, Calgary, T1Y 4E5",
+    "coordinates": {
+      "latitude": 51.0916085,
+      "longitude": -113.9520823
+    },
+    "trucks": [
+      "4"
+    ],
+    "assignedStaff": [
+      "10",
+      "7",
+      "9",
+      "6",
+      "8"
+    ],
+    "requiredServers": 5,
+    "status": "Scheduled",
+    "contactName": "TEHJIB SINGH",
+    "contactEmail": "062tehjibsingh@gmail.com",
+    "contactPhone": "3682995830"
+  },
+  {
+    "id": "18",
+    "title": "TEHJIB SINGH",
+    "startTime": "2025-06-12T14:00",
+    "endTime": "2025-06-12T17:00",
+    "location": "24 castleridge way ne NE, Calgary, T3J 2A3",
+    "coordinates": {
+      "latitude": 51.1076955,
+      "longitude": -113.9495833
+    },
+    "trucks": [
+      "13"
+    ],
+    "assignedStaff": [
+      "7",
+      "9",
+      "10",
+      "6",
+      "8"
+    ],
+    "requiredServers": 5,
+    "status": "Scheduled",
+    "contactName": "TEHJIB SINGH",
+    "contactEmail": "062tehjibsingh@gmail.com",
+    "contactPhone": "3682995830"
+  },
+  {
+    "id": "19",
+    "title": "rana party",
+    "startTime": "2025-06-12T08:00",
+    "endTime": "2025-06-12T17:00",
+    "location": "7064 temple drive NE, Calgary, T1Y 4E5",
+    "coordinates": {
+      "latitude": 51.0916085,
+      "longitude": -113.9520823
+    },
+    "trucks": [
+      "5"
+    ],
+    "assignedStaff": [
+      "10",
+      "7",
+      "9",
+      "6",
+      "8"
+    ],
+    "requiredServers": 5,
+    "status": "Scheduled",
+    "contactName": "TEHJIB SINGH",
+    "contactEmail": "062tehjibsingh@gmail.com",
+    "contactPhone": "3682995830"
   }
 ]


### PR DESCRIPTION
Summary
This PR adds UI and behavior changes to allow marking trucks as "Down for Service", and prevents them from being scheduled in events.

Features
UI Changes:

Added a checkbox labeled “Down for Service” in the TruckCard and Edit Truck page.

When checked, a red warning message is shown on the truck card.

Behavioral Changes:

Events assigned to trucks marked down for service are hidden from the schedule.

Truck remains unavailable until manually unchecked by the user.

Files Updated:

app/trucks/[id]/page.tsx

app/types.ts

How to Test
Edit a truck and check the "Down for Service" option.

Go to the schedule page.

Events for that truck should no longer appear.

Uncheck the option to make the truck available again.