### PR TITLE
fix: Add missing refs in employee form and improve invite API validation

### DIFF
--- a/app/api/invite/route.ts
+++ b/app/api/invite/route.ts
@@ -14,6 +14,32 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Email is required" }, { status: 400 });
   }
 
+  if (!wage || wage === "") {
+    return NextResponse.json({ error: "Wage is required" }, { status: 400 });
+  }
+
+  if (!employeeType || employeeType === "") {
+    return NextResponse.json(
+      { error: "Employee type is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!["Driver", "Server"].includes(employeeType)) {
+    return NextResponse.json(
+      { error: "Employee type must be either 'Driver' or 'Server'" },
+      { status: 400 }
+    );
+  }
+
+  const wageNumber = Number(wage);
+  if (isNaN(wageNumber) || wageNumber <= 0) {
+    return NextResponse.json(
+      { error: "Wage must be a positive number" },
+      { status: 400 }
+    );
+  }
+
   // Log environment variables for debugging (remove in production)
   console.log("Environment check:", {
     hasSupabaseUrl: !!process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -53,10 +79,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: employeeError.message }, { status: 500 });
   }
 
-  await supabase.from("wages").insert({
+  const wageData = {
     employee_id: employeeData?.employee_id,
-    wage: wage,
-  });
+    hourly_wage: wageNumber,
+    start_date: new Date().toISOString(),
+  };
+
+  await supabase.from("wage").insert(wageData);
 
   return NextResponse.json({ user: data.user });
 }

--- a/app/employees/newEmployee/page.tsx
+++ b/app/employees/newEmployee/page.tsx
@@ -116,7 +116,7 @@ export default function InviteEmployee(): ReactElement {
           <label htmlFor="employeeType" className="input-label">
             Employee Type
           </label>
-          <select id="employeeType" className="input">
+          <select id="employeeType" ref={employeeTypeRef} className="input">
             <option value="Driver">Driver</option>
             <option value="Server">Server</option>
           </select>
@@ -129,6 +129,7 @@ export default function InviteEmployee(): ReactElement {
           <input
             type="number"
             id="wage"
+            ref={wageRef}
             className="input"
             placeholder="Enter wage"
             required


### PR DESCRIPTION
##  Bug Fixes

### Employee Invite Form (`/employees/newEmployee`)
- **Missing refs**: Added `ref={wageRef}` and `ref={employeeTypeRef}` to form inputs
- **Data capture**: Fixed wage and employee type values not being captured properly
- **Form submission**: Now correctly sends all form data to the API

### Invite API Route (`/api/invite`)
- **Wage validation**: Added validation for required wage field and positive number check
- **Employee type validation**: Added validation for required employee type (Driver/Server only)
- **Start date**: Automatically set current date for wage records
- **Error handling**: Improved error messages and validation logic

