### PR TITLE
feat(employee-availability): modified employee availability schema and install react query

### DIFF
--- a/app/components/ClientLayoutContent.tsx
+++ b/app/components/ClientLayoutContent.tsx
@@ -6,10 +6,13 @@ import { TutorialProvider, TutorialOverlay } from "@/app/tutorial";
 import { Footer } from "./Footer";
 import Header from "./Header";
 import QuickActions from "./QuickActions";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 interface ClientLayoutContentProps {
   children: ReactNode;
 }
+
+export const queryClient = new QueryClient();
 
 export function ClientLayoutContent({ children }: ClientLayoutContentProps) {
   const pathname = usePathname();
@@ -33,14 +36,16 @@ export function ClientLayoutContent({ children }: ClientLayoutContentProps) {
   }
 
   return (
-    <TutorialProvider>
-      <Header />
-      <main className="container dashboard-grid flex-grow">
-        <QuickActions />
-        <div className="main-content p-4">{children}</div>
-      </main>
-      <Footer />
-      <TutorialOverlay />
-    </TutorialProvider>
+    <QueryClientProvider client={queryClient}>
+      <TutorialProvider>
+        <Header />
+        <main className="container dashboard-grid flex-grow">
+          <QuickActions />
+          <div className="main-content p-4">{children}</div>
+        </main>
+        <Footer />
+        <TutorialOverlay />
+      </TutorialProvider>
+    </QueryClientProvider>
   );
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -9,6 +9,7 @@ export type Employee = Tables<"employees"> & {
   addresses?: Tables<"addresses">;
   currentWage?: number;
 };
+export type EmployeeAvailability = Tables<"employee_availability">;
 export type Truck = Tables<"trucks">;
 export type TruckAssignment = Tables<"truck_assignment">;
 export type TruckAssignmentCreate = {

--- a/database.types.ts
+++ b/database.types.ts
@@ -7,6 +7,11 @@ export type Json =
   | Json[];
 
 export type Database = {
+  // Allows to automatically instanciate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "12.2.3 (519615d)";
+  };
   public: {
     Tables: {
       addresses: {
@@ -90,6 +95,41 @@ export type Database = {
             isOneToOne: false;
             referencedRelation: "events";
             referencedColumns: ["id"];
+          },
+        ];
+      };
+      employee_availability: {
+        Row: {
+          created_at: string;
+          day_of_week: string;
+          employee_id: string;
+          end_time: string;
+          id: string;
+          start_time: string;
+        };
+        Insert: {
+          created_at?: string;
+          day_of_week: string;
+          employee_id: string;
+          end_time: string;
+          id?: string;
+          start_time: string;
+        };
+        Update: {
+          created_at?: string;
+          day_of_week?: string;
+          employee_id?: string;
+          end_time?: string;
+          id?: string;
+          start_time?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "employee_availability_employee_id_fkey";
+            columns: ["employee_id"];
+            isOneToOne: false;
+            referencedRelation: "employees";
+            referencedColumns: ["employee_id"];
           },
         ];
       };
@@ -396,21 +436,28 @@ export type Database = {
   };
 };
 
-type DefaultSchema = Database[Extract<keyof Database, "public">];
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<
+  keyof Database,
+  "public"
+>];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-    | { schema: keyof Database },
+    | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R;
     }
     ? R
@@ -428,14 +475,16 @@ export type Tables<
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
-    | { schema: keyof Database },
+    | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
-  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I;
     }
     ? I
@@ -451,14 +500,16 @@ export type TablesInsert<
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
-    | { schema: keyof Database },
+    | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
-  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U;
     }
     ? U
@@ -474,14 +525,16 @@ export type TablesUpdate<
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
-    | { schema: keyof Database },
+    | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
-> = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never;
@@ -489,14 +542,16 @@ export type Enums<
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
-    | { schema: keyof Database },
+    | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
-> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never;

--- a/lib/supabase/employeeAvailability.ts
+++ b/lib/supabase/employeeAvailability.ts
@@ -19,46 +19,28 @@ export const employeeAvailabilityApi = {
     return data || [];
   },
 
-  async createEmployeeAvailability(
+  async upsertEmployeeAvailability(
     employeeId: string,
     availability: EmployeeAvailability
   ): Promise<EmployeeAvailability> {
     const { data, error } = await supabase
       .from("employee_availability")
-      .insert(availability)
+      .upsert({ ...availability, employee_id: employeeId })
       .select()
       .single();
 
     if (error) {
-      throw new Error("Failed to create employee availability");
+      throw new Error("Failed to upsert employee availability");
     }
 
     return data;
   },
 
-  async updateEmployeeAvailability(
-    employeeId: string,
-    availability: EmployeeAvailability
-  ): Promise<EmployeeAvailability> {
-    const { data, error } = await supabase
-      .from("employee_availability")
-      .update(availability)
-      .eq("employee_id", employeeId)
-      .select()
-      .single();
-
-    if (error) {
-      throw new Error("Failed to update employee availability");
-    }
-
-    return data;
-  },
-
-  async deleteEmployeeAvailability(employeeId: string): Promise<void> {
+  async deleteEmployeeAvailability(availabilityId: string): Promise<void> {
     const { error } = await supabase
       .from("employee_availability")
       .delete()
-      .eq("employee_id", employeeId);
+      .eq("id", availabilityId);
 
     if (error) {
       throw new Error("Failed to delete employee availability");

--- a/lib/supabase/employeeAvailability.ts
+++ b/lib/supabase/employeeAvailability.ts
@@ -1,0 +1,67 @@
+import { createClient } from "./client";
+import { EmployeeAvailability } from "@/app/types";
+
+const supabase = createClient();
+
+export const employeeAvailabilityApi = {
+  async getEmployeeAvailability(
+    employeeId: string
+  ): Promise<EmployeeAvailability[]> {
+    const { data, error } = await supabase
+      .from("employee_availability")
+      .select("*")
+      .eq("employee_id", employeeId);
+
+    if (error) {
+      throw new Error("Failed to fetch employee availability");
+    }
+
+    return data || [];
+  },
+
+  async createEmployeeAvailability(
+    employeeId: string,
+    availability: EmployeeAvailability
+  ): Promise<EmployeeAvailability> {
+    const { data, error } = await supabase
+      .from("employee_availability")
+      .insert(availability)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error("Failed to create employee availability");
+    }
+
+    return data;
+  },
+
+  async updateEmployeeAvailability(
+    employeeId: string,
+    availability: EmployeeAvailability
+  ): Promise<EmployeeAvailability> {
+    const { data, error } = await supabase
+      .from("employee_availability")
+      .update(availability)
+      .eq("employee_id", employeeId)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error("Failed to update employee availability");
+    }
+
+    return data;
+  },
+
+  async deleteEmployeeAvailability(employeeId: string): Promise<void> {
+    const { error } = await supabase
+      .from("employee_availability")
+      .delete()
+      .eq("employee_id", employeeId);
+
+    if (error) {
+      throw new Error("Failed to delete employee availability");
+    }
+  },
+};

--- a/lib/supabase/employees.ts
+++ b/lib/supabase/employees.ts
@@ -132,4 +132,40 @@ export const employeesApi = {
       throw new Error("Failed to delete employee");
     }
   },
+
+  async checkIfPhoneExists(
+    phone: string,
+    employeeId: string
+  ): Promise<boolean> {
+    const { data, error } = await supabase
+      .from("employees")
+      .select("*")
+      .eq("user_phone", phone)
+      .neq("employee_id", employeeId)
+      .single();
+
+    if (error) {
+      throw new Error("Failed to check if phone exists");
+    }
+
+    return data !== null;
+  },
+
+  async checkIfEmailExists(
+    email: string,
+    employeeId: string
+  ): Promise<boolean> {
+    const { data, error } = await supabase
+      .from("employees")
+      .select("*")
+      .eq("user_email", email)
+      .neq("employee_id", employeeId)
+      .single();
+
+    if (error) {
+      throw new Error("Failed to check if email exists");
+    }
+
+    return data !== null;
+  },
 };

--- a/lib/supabase/wages.ts
+++ b/lib/supabase/wages.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/client";
-import { TablesInsert, TablesUpdate } from "@/database.types";
+import { TablesInsert } from "@/database.types";
 
 const supabase = createClient();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.50.0",
+        "@tanstack/react-query": "^5.81.5",
         "@types/lodash": "^4.17.17",
         "@types/moment": "^2.13.0",
         "@types/react-datepicker": "^6.2.0",
@@ -1430,6 +1431,30 @@
         "@tailwindcss/oxide": "4.1.10",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.10"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.81.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.5.tgz",
+      "integrity": "sha512-ZJOgCy/z2qpZXWaj/oxvodDx07XcQa9BF92c0oINjHkoqUPsmm3uG08HpTaviviZ/N9eP1f9CM7mKSEkIo7O1Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.81.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.5.tgz",
+      "integrity": "sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.81.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.50.0",
+    "@tanstack/react-query": "^5.81.5",
     "@types/lodash": "^4.17.17",
     "@types/moment": "^2.13.0",
     "@types/react-datepicker": "^6.2.0",
@@ -25,8 +26,8 @@
     "moment": "^2.30.1",
     "next": "^15.3.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
     "react-datepicker": "^8.4.0",
+    "react-dom": "^19.0.0",
     "react-icons": "^5.0.1",
     "tailwind-merge": "^3.3.0"
   },
@@ -41,8 +42,8 @@
     "eslint-config-next": "15.3.2",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.0",
-    "prettier": "^3.5.3",
     "postcss": "^8.5.4",
+    "prettier": "^3.5.3",
     "supabase": "^2.24.3",
     "tailwindcss": "^4",
     "typescript": "^5.8.3"


### PR DESCRIPTION
This PR contains two notable changes:

- installs react-query for better ergonomics with client-side API requests
- introduces a new schema/table for employee availability which includes availability time on top of availability days
  - introduces UI  the employee/{id} page to edit employee availability using the new schema
  - the form in that page now supports adding/editing/deleting availability with both day, start time, and end time fields

Follow-up:
- update employee side edit employee info page(set-up-employee-info), admin side employee list page with new availability schema
- update auto assign function with new availability schema
- delete availability field in employee table after everything is updated with new availability schema