### PR TITLE
Fix mobile sidebar close functionality for non-admin users

### DIFF
--- a/app/components/SidebarSection.tsx
+++ b/app/components/SidebarSection.tsx
@@ -67,9 +67,13 @@ export const SidebarSection = React.memo(function SidebarSection({
           href={section.mainHref}
           className="flex items-center gap-4 flex-1"
           onClick={() => {
+            // Always close sidebar on mobile, regardless of admin status
+            if (isMobile) {
+              onCloseSidebar();
+            }
+            // Only toggle dropdown if animations are enabled (admin users)
             if (!disableAnimations) {
               onToggle();
-              if (isMobile) onCloseSidebar();
             }
           }}
         >


### PR DESCRIPTION
Fix mobile sidebar close functionality for non-admin users
Allow mobile sidebar to close when non-admin users click section headers